### PR TITLE
avoid load of rndis module

### DIFF
--- a/custom-image-centos-9/boot.ipxe
+++ b/custom-image-centos-9/boot.ipxe
@@ -6,6 +6,6 @@ set net{{ INTERFACE_ID }}/netmask {{ NETMASK }}
 set net{{ INTERFACE_ID }}/gateway {{ PUBLIC_GW }}
 set net{{ INTERFACE_ID }}/dns 8.8.8.8
 
-kernel http://mirror.siena.edu/centos-stream/9-stream/BaseOS/x86_64/os/images/pxeboot/vmlinuz inst.repo=http://mirror.siena.edu/centos-stream/9-stream/BaseOS/x86_64/os/ initrd=initrd.img net.ifnames=0 biosdevname=0 ip={{ PUBLIC_IP }}::{{ PUBLIC_GW }}:{{ NETMASK }}::eth{{ INTERFACE_ID }}:off:8.8.8.8
+kernel http://mirror.siena.edu/centos-stream/9-stream/BaseOS/x86_64/os/images/pxeboot/vmlinuz inst.repo=http://mirror.siena.edu/centos-stream/9-stream/BaseOS/x86_64/os/ initrd=initrd.img modprobe.blacklist=rndis_host net.ifnames=0 biosdevname=0 ip={{ PUBLIC_IP }}::{{ PUBLIC_GW }}:{{ NETMASK }}::eth{{ INTERFACE_ID }}:off:8.8.8.8
 initrd http://mirror.siena.edu/centos-stream/9-stream/BaseOS/x86_64/os/images/pxeboot/initrd.img
 boot


### PR DESCRIPTION
rndis_host module enable a network interface that alter the network interface order and may cause the OS boot failure.