### PR TITLE
Update Terraform nomad-consul example

### DIFF
--- a/terraform/nomad-consul/main.tf
+++ b/terraform/nomad-consul/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     latitudesh = {
       source  = "latitudesh/latitudesh"
-      version = "1.1.3" # Make sure you are using the latest version published to the Terraform registry
+      version = ">= 1.1.3" # Make sure you are using the latest version published to the Terraform registry
     }
   }
 }

--- a/terraform/nomad-consul/main.tf
+++ b/terraform/nomad-consul/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     latitudesh = {
       source  = "latitudesh/latitudesh"
-      version = "0.2.6" # Make sure you are using the latest version published to the Terraform registry
+      version = "1.1.3" # Make sure you are using the latest version published to the Terraform registry
     }
   }
 }

--- a/terraform/nomad-consul/nomad-setup-scripts/nomad-client-setup.sh
+++ b/terraform/nomad-consul/nomad-setup-scripts/nomad-client-setup.sh
@@ -77,11 +77,12 @@ EOF
 # ---
 # Update Netplan with VLAN configuration
 # ---
+vlan_link=$(sudo netplan get network.ethernets | grep -v '^[[:blank:]]' | tail -n 1 | sed 's/.$//')
 
 echo "    vlans:" >> /etc/netplan/50-cloud-init.yaml
 echo "        vlan.$vlanID:" >> /etc/netplan/50-cloud-init.yaml
 echo "            id: $vlanID" >> /etc/netplan/50-cloud-init.yaml
-echo "            link: eno2" >> /etc/netplan/50-cloud-init.yaml
+echo "            link: $vlan_link" >> /etc/netplan/50-cloud-init.yaml
 echo "            addresses: [$nomad_client_ip/24]" >> /etc/netplan/50-cloud-init.yaml
 
 # Apply Netplan configuration

--- a/terraform/nomad-consul/nomad-setup-scripts/nomad-installations.sh
+++ b/terraform/nomad-consul/nomad-setup-scripts/nomad-installations.sh
@@ -9,7 +9,7 @@
 # to have Ubuntu only list the services instead.
 #
 # Comment out this line if you are not standing up Ubuntu 22.04.
-echo "\\$nrconf{restart} = 'l'" >> /etc/needrestart/needrestart.conf
+echo "\$nrconf{restart} = 'l'" >> /etc/needrestart/conf.d/no-prompt.conf
 
 # Update the system
 apt-get update -qq
@@ -63,4 +63,3 @@ curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o /etc/
 echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null
 apt update
 apt install -yq docker-ce docker-ce-cli containerd.io docker-compose-plugin
-

--- a/terraform/nomad-consul/nomad-setup-scripts/nomad-server-setup.sh
+++ b/terraform/nomad-consul/nomad-setup-scripts/nomad-server-setup.sh
@@ -79,11 +79,12 @@ EOF
 # ---
 # Update Netplan with VLAN configuration
 # ---
+vlan_link=$(sudo netplan get network.ethernets | grep -v '^[[:blank:]]' | tail -n 1 | sed 's/.$//')
 
 echo "    vlans:" >> /etc/netplan/50-cloud-init.yaml
 echo "        vlan.$vlanID:" >> /etc/netplan/50-cloud-init.yaml
 echo "            id: $vlanID" >> /etc/netplan/50-cloud-init.yaml
-echo "            link: eno2" >> /etc/netplan/50-cloud-init.yaml
+echo "            link: $vlan_link" >> /etc/netplan/50-cloud-init.yaml
 echo "            addresses: [$nomad_server_ip/24]" >> /etc/netplan/50-cloud-init.yaml
 
 # Apply Netplan configuration

--- a/terraform/nomad-consul/nomad_clients.tf
+++ b/terraform/nomad-consul/nomad_clients.tf
@@ -1,7 +1,7 @@
 resource "latitudesh_server" "nomad_clients" {
   count            = var.nomad_client_count
   hostname         = "nomad-client-${count.index + 1}"
-  operating_system = "ubuntu_24_04_x64_lts"
+  operating_system = var.operating_system
   site             = var.nomad_region
   plan             = var.plan
   project          = var.project_id

--- a/terraform/nomad-consul/nomad_clients.tf
+++ b/terraform/nomad-consul/nomad_clients.tf
@@ -1,9 +1,9 @@
 resource "latitudesh_server" "nomad_clients" {
   count            = var.nomad_client_count
   hostname         = "nomad-client-${count.index + 1}"
-  operating_system = "ubuntu_22_04_x64_lts"
+  operating_system = "ubuntu_24_04_x64_lts"
   site             = var.nomad_region
-  plan             = "c2-small-x86"
+  plan             = var.plan
   project          = var.project_id
   ssh_keys         = [var.ssh_key_id]
 
@@ -32,7 +32,7 @@ resource "latitudesh_server" "nomad_clients" {
 
 resource "null_resource" "nomad_clients_post_script" {
   count      = var.nomad_client_count
-  depends_on = [latitudesh_server.nomad_clients, null_resource.nomad_servers_post_script]
+  depends_on = [latitudesh_server.nomad_clients, null_resource.nomad_servers_post_script, latitudesh_vlan_assignment.assign_clients]
 
   connection {
     type        = "ssh"
@@ -51,8 +51,7 @@ resource "null_resource" "nomad_clients_post_script" {
     inline = [
       # Add executable permission to the script, the execute it.
       "chmod +x /tmp/nomad-client-setup.sh",
-      "sudo /tmp/nomad-client-setup.sh ${count.index + 10} ${var.nomad_server_count} ${var.nomad_region} ${var.nomad_vlan_id}"
+      "sudo /tmp/nomad-client-setup.sh ${count.index + 10} ${var.nomad_server_count} ${var.nomad_region} ${latitudesh_virtual_network.nomad_vlan.vid}"
     ]
   }
 }
-

--- a/terraform/nomad-consul/nomad_servers.tf
+++ b/terraform/nomad-consul/nomad_servers.tf
@@ -1,7 +1,7 @@
 resource "latitudesh_server" "nomad_servers" {
   count            = var.nomad_server_count
   hostname         = "nomad-server-${count.index + 1}"
-  operating_system = "ubuntu_24_04_x64_lts"
+  operating_system = var.operating_system
   site             = var.nomad_region
   plan             = var.plan
   project          = var.project_id

--- a/terraform/nomad-consul/nomad_servers.tf
+++ b/terraform/nomad-consul/nomad_servers.tf
@@ -1,7 +1,7 @@
 resource "latitudesh_server" "nomad_servers" {
   count            = var.nomad_server_count
   hostname         = "nomad-server-${count.index + 1}"
-  operating_system = "ubuntu_22_04_x64_lts"
+  operating_system = "ubuntu_24_04_x64_lts"
   site             = var.nomad_region
   plan             = var.plan
   project          = var.project_id
@@ -37,7 +37,7 @@ resource "latitudesh_server" "nomad_servers" {
 
 resource "null_resource" "nomad_servers_post_script" {
   count      = var.nomad_server_count
-  depends_on = [latitudesh_server.nomad_servers]
+  depends_on = [latitudesh_server.nomad_servers, latitudesh_vlan_assignment.assign_servers]
 
   provisioner "file" {
 
@@ -62,7 +62,7 @@ resource "null_resource" "nomad_servers_post_script" {
     inline = [
       # Add executable permission to the script, the execute it.
       "chmod +x /tmp/nomad-server-setup.sh",
-      "sudo /tmp/nomad-server-setup.sh ${count.index + 1} ${var.nomad_server_count} ${var.nomad_region} ${var.nomad_vlan_id}"
+      "sudo /tmp/nomad-server-setup.sh ${count.index + 1} ${var.nomad_server_count} ${var.nomad_region} ${latitudesh_virtual_network.nomad_vlan.vid}"
     ]
   }
 }

--- a/terraform/nomad-consul/variables.tf
+++ b/terraform/nomad-consul/variables.tf
@@ -14,6 +14,11 @@ variable "plan" {
   default     = ""
 }
 
+variable "operating_system" {
+  description = "Operating system to use for the instances. You can find this in the /plans/operating_systems endpoint of the API."
+  default     = "ubuntu_24_04_x64_lts"
+}
+
 // Nomad setup
 variable "nomad_server_count" {
   description = "The number of Nomad/Consul server instances to create."

--- a/virtual_network.tf
+++ b/virtual_network.tf
@@ -1,0 +1,17 @@
+resource "latitudesh_virtual_network" "nomad_vlan" {
+  description      = "nomad_vlan"
+  site             = var.nomad_region
+  project          = var.project_id
+}
+
+resource "latitudesh_vlan_assignment" "assign_servers" {
+  count            = var.nomad_server_count
+  server_id = latitudesh_server.nomad_servers.*.id[count.index]
+  virtual_network_id = latitudesh_virtual_network.nomad_vlan.id
+}
+
+resource "latitudesh_vlan_assignment" "assign_clients" {
+  count            = var.nomad_client_count
+  server_id = latitudesh_server.nomad_clients.*.id[count.index]
+  virtual_network_id = latitudesh_virtual_network.nomad_vlan.id
+}


### PR DESCRIPTION
## What does this PR do
Update the nomad-consul example to avoid errors and better usability

## How
- Update Provider Version
- Avoid writing directly to `/etc/needrestart/needrestart.conf`, which might cause the following error: 
```
Can't modify reference to anonymous hash ({}) in scalar assignment at (eval 12) line 229, at EOF
```
- Create a virtual network and assign it with Terraform so users don't have to go to the dashboard
- Grep the ethernet to use as a VLAN link. Having it hardcoded as `eno2` was causing errors when `eno2` didn't exist in the file. Sometimes the second Ethernet interface would be `enp1s0f1`

## How to Test
- Copy the files that are in the `nomad-consul` folder
- Run `terraform init`
- Fill in the necessary information in the `variables.tf` file
- Run `terraform apply` to apply the changes

## References
https://www.latitude.sh/guides/nomad-consul-terraform