### PR TITLE
Fix: Disable rndis_host module for custom images v2

### DIFF
--- a/custom-images-v2/almalinux-9/README.md
+++ b/custom-images-v2/almalinux-9/README.md
@@ -1,0 +1,3 @@
+# AlmaLinux 9
+
+This example features deploying AlmaLinux, an Open Source and forever-free enterprise Linux distribution, governed and driven by the community, focused on long-term stability and a robust production grade platform. AlmaLinux OS is binary compatible with RHEL®.

--- a/custom-images-v2/almalinux-9/boot.ipxe
+++ b/custom-images-v2/almalinux-9/boot.ipxe
@@ -1,0 +1,5 @@
+#!ipxe
+
+kernel http://repo.almalinux.org/almalinux/9/BaseOS/x86_64/os/images/pxeboot/vmlinuz inst.repo=http://repo.almalinux.org/almalinux/9/BaseOS/x86_64/os/ initrd=initrd.img modprobe.blacklist=rndis_host net.ifnames=0 biosdevname=0 ip=dhcp
+initrd http://repo.almalinux.org/almalinux/9/BaseOS/x86_64/os/images/pxeboot/initrd.img
+boot

--- a/custom-images-v2/ubuntu-22/boot.ipxe
+++ b/custom-images-v2/ubuntu-22/boot.ipxe
@@ -1,7 +1,7 @@
 #!ipxe
 
-kernel https://github.com/latitudesh/examples/releases/download/us_22.04_amd64/vmlinuz  initrd=initrd  url=http://releases.ubuntu.com/jammy/ubuntu-22.04.5-live-server-amd64.iso net.ifnames=0 biosdevname=0 ip=dhcp
+kernel https://github.com/latitudesh/examples/releases/download/us_22.04_amd64/vmlinuz  initrd=initrd  url=http://releases.ubuntu.com/jammy/ubuntu-22.04.5-live-server-amd64.iso net.ifnames=0 biosdevname=0 ip=dhcp modprobe.blacklist=rndis_host
 
-initrd https://github.com/latitudesh/examples/releases/download/us_22.04_amd64/initrd 
+initrd https://github.com/latitudesh/examples/releases/download/us_22.04_amd64/initrd
 
 boot

--- a/custom-images-v2/ubuntu-24/boot.ipxe
+++ b/custom-images-v2/ubuntu-24/boot.ipxe
@@ -1,6 +1,6 @@
 #!ipxe
 
-kernel https://github.com/latitudesh/examples/releases/download/us_24.04_amd64/vmlinuz  initrd=initrd  url=https://releases.ubuntu.com/noble/ubuntu-24.04.2-live-server-amd64.iso net.ifnames=0 biosdevname=0 ip=dhcp
-initrd https://github.com/latitudesh/examples/releases/download/us_24.04_amd64/initrd 
+kernel https://github.com/latitudesh/examples/releases/download/us_24.04_amd64/vmlinuz  initrd=initrd  url=https://releases.ubuntu.com/noble/ubuntu-24.04.2-live-server-amd64.iso net.ifnames=0 biosdevname=0 ip=dhcp modprobe.blacklist=rndis_host
+initrd https://github.com/latitudesh/examples/releases/download/us_24.04_amd64/initrd
 
 boot


### PR DESCRIPTION
- Update the examples from Custom Images V2 to disable the `rndis_host` module, to avoid conflicts with the primary network setup during the boot process: `modprobe.blacklist=rndis_host`.
- Add examples for AlmaLinux 9

